### PR TITLE
Fix: solving document || window is not defined for Nextjs isServer variable

### DIFF
--- a/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js
+++ b/inlang/packages/paraglide/paraglide-js/src/compiler/runtime/set-locale.js
@@ -51,7 +51,7 @@ export let setLocale = (newLocale, options) => {
 			// is likely overwritten by `defineSetLocale()`
 			_locale = newLocale;
 		} else if (TREE_SHAKE_COOKIE_STRATEGY_USED && strat === "cookie") {
-			if (isServer) {
+			if (isServer || typeof document === 'undefined') {
 				continue;
 			}
 			// set the cookie


### PR DESCRIPTION
This solves https://github.com/opral/inlang-paraglide-js/issues/474